### PR TITLE
注解路由无法解析问题

### DIFF
--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -51,7 +51,7 @@ trait InteractsWithRoute
 
     protected function scanDir($dir)
     {
-        foreach (ClassMapGenerator::createMap($dir) as $class) {
+        foreach (ClassMapGenerator::createMap($dir) as $class=>$path) {
             $refClass        = new ReflectionClass($class);
             $routeGroup      = false;
             $routeMiddleware = [];


### PR DESCRIPTION
1.1.0和1.1.1版本注解路由无法正常解析，在`InteractsWithRoute.php`第54行！