### PR TITLE
修复类注解中间件不生效的问题

### DIFF
--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -51,7 +51,7 @@ trait InteractsWithRoute
 
     protected function scanDir($dir)
     {
-        foreach (ClassMapGenerator::createMap($dir) as $class=>$path) {
+        foreach (ClassMapGenerator::createMap($dir) as $class => $path) {
             $refClass        = new ReflectionClass($class);
             $routeGroup      = false;
             $routeMiddleware = [];

--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -104,13 +104,19 @@ trait InteractsWithRoute
 
                     //中间件
                     if ($middleware = $this->reader->getMethodAnnotation($refMethod, Middleware::class)) {
-                        $rule->middleware($middleware->value);
+                        $routeMiddleware=array_merge($routeMiddleware,$middleware->value);
                     }
+                    
+                    //绑定中间件，技持绑定多个
+                    if(!empty($routeMiddleware)){
+                        $rule->middleware($routeMiddleware);
+                    }
+                    
                     //设置分组别名
                     if ($group = $this->reader->getMethodAnnotation($refMethod, Group::class)) {
                         $rule->group($group->value);
                     }
-
+                
                     //绑定模型,支持多个
                     if (!empty($models = $this->getMethodAnnotations($refMethod, Model::class))) {
                         /** @var Model $model */

--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -51,7 +51,7 @@ trait InteractsWithRoute
 
     protected function scanDir($dir)
     {
-        foreach (ClassMapGenerator::createMap($dir) as $class) {
+        foreach (ClassMapGenerator::createMap($dir) as $class=>$path) {
             $refClass        = new ReflectionClass($class);
             $routeGroup      = false;
             $routeMiddleware = [];


### PR DESCRIPTION
修复类注解中间件不生效的问题
1. 修复代码行 107行
2. 修复后，类注解中间件和方法注解中间件同时生效