### PR TITLE
[2.0] 声明依赖`php8.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": "^8.0",
         "topthink/framework": "^6.0",
         "symfony/class-loader": "~3.2.0"
     },


### PR DESCRIPTION
声明依赖`php8`，防止`7.x`安装不可用。