### PR TITLE
fix(route): The controller does not exist in multi-app mode

### DIFF
--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -87,7 +87,7 @@ trait InteractsWithRoute
 
             if (Str::startsWith($filename, $this->controllerDir)) {
                 //控制器
-                $filename = Str::substr($filename, strlen($this->controllerDir) + 1);
+                $filename = Str::substr($filename, Str::length($this->controllerDir) + 1);
                 $prefix   = str_replace($this->controllerSuffix . '.php', '', str_replace('/', '.', $filename));
             }
 


### PR DESCRIPTION
多应用模式下，注解路由无法正确识别控制器，出现“控制器不存在”的错误

> 多应用模式下，假设目录如下

```bash
app
├─module1
├───controller
├─────admin
├─────user
├───────Test.php
├─module2
├─module3
```

> Test.php

```bash
<?php
  
  namespace app\module1\controller\user;
  
  use think\annotation\route\Group;
  use think\annotation\route\Route;

  #[Group('api')]
  class Test
  {
    #[Route('GET', 'test')]
    public function index()
    {
      return 'test';
    }
  }
```


修复： 访问 `https://www.example.com/module1/api/test` ，报 "控制器不存在"的Bug