### PR TITLE
修复在Windows 下路径替换错误的bug

### DIFF
--- a/src/InteractsWithRoute.php
+++ b/src/InteractsWithRoute.php
@@ -113,7 +113,7 @@ trait InteractsWithRoute
             if (Str::startsWith($filename, $this->controllerDir)) {
                 //控制器
                 $filename = Str::substr($filename, strlen($this->controllerDir) + 1);
-                $prefix   = str_replace($this->controllerSuffix . '.php', '', str_replace('/', '.', $filename));
+                $prefix   = str_replace($this->controllerSuffix . '.php', '', str_replace(DIRECTORY_SEPARATOR, '.', $filename));
             }
 
             $routes = [];


### PR DESCRIPTION
```
   if (Str::startsWith($filename, $this->controllerDir)) {
        //控制器
        $filename = Str::substr($filename, strlen($this->controllerDir) + 1);
         // 在Windows下 如果使用 / 是无法正确替换的
        $prefix   = str_replace($this->controllerSuffix . '.php', '', str_replace('/', '.', $filename));
         // 路劲符号需要改成 DIRECTORY_SEPARATOR
        $prefix   = str_replace($this->controllerSuffix . '.php', '', str_replace(DIRECTORY_SEPARATOR, '.', $filename));
    }

```